### PR TITLE
Add cljs.reader to literals file

### DIFF
--- a/src/clojurescript/fogus/datalog/bacwn/impl/literals.cljs
+++ b/src/clojurescript/fogus/datalog/bacwn/impl/literals.cljs
@@ -19,7 +19,8 @@
 (ns fogus.datalog.bacwn.impl.literals
   (:require [fogus.datalog.bacwn.impl.util :as util]
             [fogus.datalog.bacwn.impl.database :as db]
-            clojure.set))
+            clojure.set
+            cljs.reader))
 
 ;; =============================
 ;; Type Definitions


### PR DESCRIPTION
Hi, I tried using bacwn a few days ago and noticed that it threw an error because `cljs.reader` wasn't declared in `fogus.datalog.bacwn.impl.literals`. I adjusted the namespace a bit to fix the issue.
